### PR TITLE
Update aws-lambda-java-log4j2 and log4j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,8 @@ dependencies {
     implementation 'software.amazon.awssdk:secretsmanager:2.17.24'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.4'
     implementation 'com.google.code.gson:gson:2.8.8'
-    implementation 'org.apache.logging.log4j:log4j-api:2.14.1'
-    implementation 'org.apache.logging.log4j:log4j-core:2.14.1'
+    implementation 'org.apache.logging.log4j:log4j-api:2.15.0'
+    implementation 'org.apache.logging.log4j:log4j-core:2.15.0'
 
     implementation 'com.google.protobuf:protobuf-java:3.17.3'
     implementation 'org.apache.avro:avro:1.10.2'
@@ -71,8 +71,8 @@ dependencies {
     implementation "io.confluent:kafka-protobuf-provider:6.1.1"
 
 
-    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j18-impl:2.14.1'
-    runtimeOnly 'com.amazonaws:aws-lambda-java-log4j2:1.2.0'
+    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j18-impl:2.15.0'
+    runtimeOnly 'com.amazonaws:aws-lambda-java-log4j2:1.3.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
 }


### PR DESCRIPTION
See https://aws.amazon.com/security/security-bulletins/AWS-2021-005/

`Customers using the aws-lambda-java-log4j2 (https://repo1.maven.org/maven2/com/amazonaws/aws-lambda-java-log4j2/) library in their functions will need to update to version 1.3.0 and redeploy.`