### PR TITLE
Minor: Convert to output binding

### DIFF
--- a/azure-ccloud-kafka-direct/AzureKafkaDirectTrigger.cs
+++ b/azure-ccloud-kafka-direct/AzureKafkaDirectTrigger.cs
@@ -29,8 +29,6 @@ public static class AzureDirectKafkaTrigger
         rawConfigJson = Environment.GetEnvironmentVariable("ccloud-producer-configs");
         rawSchemaRegistryConfigs = Environment.GetEnvironmentVariable("schema-registry-configs");
         var schemaConfigs = JsonConvert.DeserializeObject<Dictionary<string, string>>(rawSchemaRegistryConfigs);
-        var producerConfigs = JsonConvert.DeserializeObject<Dictionary<string, string>>(rawConfigJson);
-        producerConfigs.Add("client.id", "Confluent-Azure-Producer");
         var schemaRegistryConfig = new SchemaRegistryConfig();
         foreach (var configEntry in schemaConfigs)
         {


### PR DESCRIPTION
This updates the Function code to use the output binding by default.  A separate branch will provide the example of instantiating a stand-alone producer